### PR TITLE
Fix [-Wreturn-type] compiler warning by always returning

### DIFF
--- a/src/hc_cc_state_space/hc_cc_circle.cpp
+++ b/src/hc_cc_state_space/hc_cc_circle.cpp
@@ -106,21 +106,13 @@ double HC_CC_Circle::deflection(const Configuration &q) const
 {
   double alpha_c = this->start.theta;
   double alpha_q = q.theta;
-  if (this->left && this->forward)
+  if ((this->left && this->forward) || (!this->left && !this->forward))
   {
     return twopify(alpha_q - alpha_c);
   }
-  if (this->left && !this->forward)
+  else
   {
     return twopify(alpha_c - alpha_q);
-  }
-  if (!this->left && this->forward)
-  {
-    return twopify(alpha_c - alpha_q);
-  }
-  if (!this->left && !this->forward)
-  {
-    return twopify(alpha_q - alpha_c);
   }
 }
 

--- a/src/hc_cc_state_space/paths.cpp
+++ b/src/hc_cc_state_space/paths.cpp
@@ -306,7 +306,7 @@ int direction(bool forward, bool order)
     return -1;
   else if (!forward && order)
     return -1;
-  else if (!forward && !order)
+  else // (!forward && !order)
     return 1;
 }
 

--- a/src/hc_cc_state_space/paths.cpp
+++ b/src/hc_cc_state_space/paths.cpp
@@ -300,14 +300,10 @@ void straight_controls(const Configuration &q1, const Configuration &q2, vector<
 
 int direction(bool forward, bool order)
 {
-  if (forward && order)
+  if ((forward && order) || (!forward && !order))
     return 1;
-  else if (forward && !order)
+  else
     return -1;
-  else if (!forward && order)
-    return -1;
-  else // (!forward && !order)
-    return 1;
 }
 
 void rs_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, vector<Control> &controls)


### PR DESCRIPTION
It's a default compiler warning under ubuntu 20.04 it seems.

Refactored code a little so it always returns.