### PR TITLE
Fix catkin failed build when testing is not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,31 +203,32 @@ install(DIRECTORY
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
-if(TARGET steering_functions_test)
-  target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-endif()
+if(CATKIN_ENABLE_TESTING)
+  ## Add gtest based cpp test target and link libraries
+  catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
+  if(TARGET steering_functions_test)
+    target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
-if(TARGET fresnel_test)
-  target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-endif()
+  catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
+  if(TARGET fresnel_test)
+    target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(timing_test test/timing_test.cpp)
-if(TARGET timing_test)
-  target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-endif()
+  catkin_add_gtest(timing_test test/timing_test.cpp)
+  if(TARGET timing_test)
+    target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
-if(TARGET jacobian_test)
-  target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-endif()
+  catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
+  if(TARGET jacobian_test)
+    target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  endif()
 
-catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
-if(TARGET hc_cc_circle_test)
-  target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
+  if(TARGET hc_cc_circle_test)
+    target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+  endif()
 endif()
-
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,5 +230,6 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
   endif()
 endif()
+
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)


### PR DESCRIPTION
On a clean catkin_build I get thrown this error:

```
Errors     << steering_functions:check /home/mcfurry/ros/melodic/system/logs/steering_functions/build.check.000.log                                                                                               
CMake Error at /opt/ros/melodic/share/catkin/cmake/test/tests.cmake:18 (message):
  () is not available when tests are not enabled.  The CMake code should only
  use it inside a conditional block which checks that testing is enabled:

  if(CATKIN_ENABLE_TESTING)

    (...)

  endif()

Call Stack (most recent call first):
  CMakeLists.txt:207 (catkin_add_gtest)


make: *** [cmake_check_build_system] Error 1
```

This fixes this.