### PR TITLE
Changed to proper namespace 'steering', removed 'using namespace' in header files and cleaned up includes

### DIFF
--- a/include/steering_functions/dubins_state_space/dubins_state_space.hpp
+++ b/include/steering_functions/dubins_state_space/dubins_state_space.hpp
@@ -60,16 +60,12 @@
 #ifndef __DUBINS_STATE_SPACE_HPP_
 #define __DUBINS_STATE_SPACE_HPP_
 
-#include <algorithm>
 #include <cassert>
-#include <cmath>
-#include <iostream>
 #include <limits>
 #include <vector>
 
 #include "steering_functions/filter/ekf.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/dubins_state_space/dubins_state_space.hpp
+++ b/include/steering_functions/dubins_state_space/dubins_state_space.hpp
@@ -71,8 +71,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief An SE(2) state space where distance is measured by the
     length of Dubins curves.
@@ -107,7 +107,7 @@ public:
   public:
     /** \brief Constructor of the Dubins_Path */
     Dubins_Path(const Dubins_Path_Segment_Type *type = dubins_path_type[0], double t = 0.,
-                double p = numeric_limits<double>::max(), double q = 0.)
+                double p = std::numeric_limits<double>::max(), double q = 0.)
       : type_(type)
     {
       length_[0] = t;
@@ -152,24 +152,24 @@ public:
   double get_distance(const State &state1, const State &state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 with curvature = kappa_ */
-  vector<Control> get_controls(const State &state1, const State &state2) const;
+  std::vector<Control> get_controls(const State &state1, const State &state2) const;
 
   /** \brief Returns shortest path from state1 to state2 with curvature = kappa_ */
-  vector<State> get_path(const State &state1, const State &state2) const;
+  std::vector<State> get_path(const State &state1, const State &state2) const;
 
   /** \brief Returns shortest path including covariances from state1 to state2 with curvature = kappa_ */
-  vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance &state1,
-                                                         const State &state2) const;
+  std::vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance &state1,
+                                                              const State &state2) const;
 
   /** \brief Returns integrated states given a start state and controls with curvature = kappa_ */
-  vector<State> integrate(const State &state, const vector<Control> &controls) const;
+  std::vector<State> integrate(const State &state, const std::vector<Control> &controls) const;
 
   /** \brief Returns integrated states including covariance given a start state and controls with curvature = kappa_ */
-  vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance &state,
-                                                          const vector<Control> &controls) const;
+  std::vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance &state,
+                                                               const std::vector<Control> &controls) const;
 
   /** \brief Returns interpolated state at distance t in [0,1] (percent of total path length with curvature = kappa_) */
-  State interpolate(const State &state, const vector<Control> &controls, double t) const;
+  State interpolate(const State &state, const std::vector<Control> &controls, double t) const;
 
   /** \brief Returns integrated state given a start state, a control, and an integration step */
   inline State integrate_ODE(const State &state, const Control &control, double integration_step) const;
@@ -190,5 +190,7 @@ private:
   /** \brief Extended Kalman Filter for uncertainty propagation */
   EKF ekf_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/filter/ekf.hpp
+++ b/include/steering_functions/filter/ekf.hpp
@@ -25,8 +25,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 typedef Eigen::Matrix<double, 2, 2> Matrix2d;
 typedef Eigen::Matrix<double, 3, 3> Matrix3d;
@@ -92,5 +92,7 @@ private:
   /** \brief Identity matrix */
   Matrix3d I_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/filter/ekf.hpp
+++ b/include/steering_functions/filter/ekf.hpp
@@ -18,12 +18,9 @@
 #ifndef EKF_HPP
 #define EKF_HPP
 
-#include <iostream>
-
 #include <Eigen/Dense>
 
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Dubins car
@@ -67,7 +67,7 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Driving direction */
@@ -77,7 +77,9 @@ private:
   class CC00_Dubins;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<CC00_Dubins> cc00_dubins_;
+  std::unique_ptr<CC00_Dubins> cc00_dubins_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef CC00_DUBINS_STATE_SPACE_HPP
 #define CC00_DUBINS_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/cc00_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc00_reeds_shepp_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Reeds-Shepp
@@ -71,14 +71,16 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Pimpl Idiom: class that contains functions to compute the families  */
   class CC00_Reeds_Shepp;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<CC00_Reeds_Shepp> cc00_reeds_shepp_;
+  std::unique_ptr<CC00_Reeds_Shepp> cc00_reeds_shepp_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/cc00_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc00_reeds_shepp_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef CC00_REEDS_SHEPP_STATE_SPACE_HPP
 #define CC00_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef CC0PM_DUBINS_STATE_SPACE_HPP
 #define CC0PM_DUBINS_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Dubins car
@@ -66,7 +66,7 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Driving direction */
@@ -76,7 +76,7 @@ private:
   class CC0pm_Dubins;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<CC0pm_Dubins> cc0pm_dubins_;
+  std::unique_ptr<CC0pm_Dubins> cc0pm_dubins_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -87,5 +87,7 @@ private:
   /** \brief Angle between a configuration on the hc-/cc-circle and the tangent to the circle at that position */
   double mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp
@@ -18,22 +18,16 @@
 #ifndef CC_DUBINS_STATE_SPACE_HPP
 #define CC_DUBINS_STATE_SPACE_HPP
 
-#include <algorithm>
-#include <iostream>
-#include <limits>
-#include <memory>
+#include <utility>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp
@@ -35,8 +35,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Dubins car
@@ -49,13 +49,13 @@ public:
   CC_Dubins_State_Space(double kappa, double sigma, double discretization = 0.1, bool forwards = true);
 
   /** \brief Predicts a state forwards or backwards to zero and max. curvature */
-  vector<pair<State, Control>> predict_state(const State& state, bool forwards) const;
+  std::vector<std::pair<State, Control>> predict_state(const State& state, bool forwards) const;
 
   /** \brief Returns shortest path length from state1 to state2 */
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Driving direction */
@@ -67,5 +67,7 @@ private:
   CCpm0_Dubins_State_Space ccpm0_dubins_state_space_;
   CCpmpm_Dubins_State_Space ccpmpm_dubins_state_space_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Dubins car
@@ -66,7 +66,7 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Driving direction */
@@ -76,7 +76,7 @@ private:
   class CCpm0_Dubins;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<CCpm0_Dubins> ccpm0_dubins_;
+  std::unique_ptr<CCpm0_Dubins> ccpm0_dubins_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -87,5 +87,7 @@ private:
   /** \brief Angle between a configuration on the hc-/cc-circle and the tangent to the circle at that position */
   double mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef CCPM0_DUBINS_STATE_SPACE_HPP
 #define CCPM0_DUBINS_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of continuous curvature (CC) steer for a Dubins car
@@ -67,7 +67,7 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Driving direction */
@@ -77,7 +77,7 @@ private:
   class CCpmpm_Dubins;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<CCpmpm_Dubins> ccpmpm_dubins_;
+  std::unique_ptr<CCpmpm_Dubins> ccpmpm_dubins_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -91,5 +91,7 @@ private:
   /** \brief Sine and cosine of mu */
   double sin_mu_, cos_mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef CCPMPM_DUBINS_STATE_SPACE_HPP
 #define CCPMPM_DUBINS_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/configuration.hpp
+++ b/include/steering_functions/hc_cc_state_space/configuration.hpp
@@ -30,7 +30,8 @@
 
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
+namespace steering
+{
 
 class Configuration
 {
@@ -59,5 +60,7 @@ bool configuration_aligned(const Configuration &q1, const Configuration &q2);
 
 /** \brief Are two configurations equal? */
 bool configuration_equal(const Configuration &q1, const Configuration &q2);
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/configuration.hpp
+++ b/include/steering_functions/hc_cc_state_space/configuration.hpp
@@ -26,10 +26,6 @@
 #ifndef CONFIGURATION_HPP
 #define CONFIGURATION_HPP
 
-#include <iostream>
-
-#include "steering_functions/utilities/utilities.hpp"
-
 namespace steering
 {
 

--- a/include/steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of hybrid curvature (HC) steer with zero curvature at
@@ -70,17 +70,19 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Pimpl Idiom: class that contains functions to compute the families  */
   class HC00_Reeds_Shepp;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<HC00_Reeds_Shepp> hc00_reeds_shepp_;
+  std::unique_ptr<HC00_Reeds_Shepp> hc00_reeds_shepp_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef HC00_REEDS_SHEPP_STATE_SPACE_HPP
 #define HC00_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef HC0PM_REEDS_SHEPP_STATE_SPACE_HPP
 #define HC0PM_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of hybrid curvature (HC) steer with zero curvature at
@@ -71,14 +71,14 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Pimpl Idiom: class that contains functions to compute the families  */
   class HC0pm_Reeds_Shepp;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<HC0pm_Reeds_Shepp> hc0pm_reeds_shepp_;
+  std::unique_ptr<HC0pm_Reeds_Shepp> hc0pm_reeds_shepp_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -89,5 +89,7 @@ private:
   /** \brief Angle between a configuration on the hc-/cc-circle and the tangent to the circle at that position */
   double mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hc_cc_circle.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_cc_circle.hpp
@@ -26,12 +26,7 @@
 #ifndef HC_CC_CIRCLE_HPP
 #define HC_CC_CIRCLE_HPP
 
-#include <cassert>
-#include <iostream>
-#include <limits>
-
-#include "configuration.hpp"
-#include "steering_functions/utilities/utilities.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hc_cc_circle.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_cc_circle.hpp
@@ -33,7 +33,8 @@
 #include "configuration.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
+namespace steering
+{
 
 class HC_CC_Circle_Param
 {
@@ -118,5 +119,7 @@ double center_distance(const HC_CC_Circle &c1, const HC_CC_Circle &c2);
 
 /** \brief Configuration on the circle? */
 bool configuration_on_hc_cc_circle(const HC_CC_Circle &c, const Configuration &q);
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hc_cc_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_cc_state_space.hpp
@@ -18,13 +18,11 @@
 #ifndef HC_CC_STATE_SPACE_HPP
 #define HC_CC_STATE_SPACE_HPP
 
-#include <cmath>
 #include <vector>
 
 #include "steering_functions/filter/ekf.hpp"
 #include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hc_cc_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_cc_state_space.hpp
@@ -26,8 +26,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 class HC_CC_State_Space
 {
@@ -40,24 +40,24 @@ public:
                              const Controller& controller);
 
   /** \brief Virtual function that returns controls of the shortest path from state1 to state2 */
-  virtual vector<Control> get_controls(const State& state1, const State& state2) const = 0;
+  virtual std::vector<Control> get_controls(const State& state1, const State& state2) const = 0;
 
   /** \brief Returns path from state1 to state2 */
-  vector<State> get_path(const State& state1, const State& state2) const;
+  std::vector<State> get_path(const State& state1, const State& state2) const;
 
   /** \brief Returns path including covariances from state1 to state2 */
-  vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance& state1,
-                                                         const State& state2) const;
+  std::vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance& state1,
+                                                              const State& state2) const;
 
   /** \brief Returns integrated states given a start state and controls */
-  vector<State> integrate(const State& state, const vector<Control>& controls) const;
+  std::vector<State> integrate(const State& state, const std::vector<Control>& controls) const;
 
   /** \brief Returns integrated states including covariance given a start state and controls */
-  vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance& state,
-                                                          const vector<Control>& controls) const;
+  std::vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance& state,
+                                                               const std::vector<Control>& controls) const;
 
   /** \brief Returns interpolated state at distance t in [0,1] (percentage of total path length) */
-  State interpolate(const State& state, const vector<Control>& controls, double t) const;
+  State interpolate(const State& state, const std::vector<Control>& controls, double t) const;
 
   /** \brief Returns integrated state given a start state, a control, and an integration step */
   inline State integrate_ODE(const State& state, const Control& control, double integration_step) const;
@@ -75,5 +75,7 @@ protected:
   /** \brief Extended Kalman Filter for uncertainty propagation */
   EKF ekf_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp
@@ -18,22 +18,15 @@
 #ifndef HC_REEDS_SHEPP_STATE_SPACE_HPP
 #define HC_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <algorithm>
-#include <iostream>
-#include <limits>
-#include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp
@@ -35,8 +35,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of hybrid curvature (HC) steer with arbitrary curvature at
@@ -49,13 +49,13 @@ public:
   HC_Reeds_Shepp_State_Space(double kappa, double sigma, double discretization = 0.1);
 
   /** \brief Predicts a state forwards and backwards to zero and max. curvature */
-  vector<pair<State, Control>> predict_state(const State& state) const;
+  std::vector<std::pair<State, Control>> predict_state(const State& state) const;
 
   /** \brief Returns shortest path length from state1 to state2 */
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Required state spaces */
@@ -64,5 +64,7 @@ private:
   HCpm0_Reeds_Shepp_State_Space hcpm0_reeds_shepp_state_space_;
   HCpmpm_Reeds_Shepp_State_Space hcpmpm_reeds_shepp_state_space_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of hybrid curvature (HC) steer with either positive
@@ -71,14 +71,14 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Pimpl Idiom: class that contains functions to compute the families  */
   class HCpm0_Reeds_Shepp;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<HCpm0_Reeds_Shepp> hcpm0_reeds_shepp_;
+  std::unique_ptr<HCpm0_Reeds_Shepp> hcpm0_reeds_shepp_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -89,5 +89,7 @@ private:
   /** \brief Angle between a configuration on the hc-/cc-circle and the tangent to the circle at that position */
   double mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef HCPM0_REEDS_SHEPP_STATE_SPACE_HPP
 #define HCPM0_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp
@@ -38,8 +38,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief
     An implementation of hybrid curvature (HC) steer with either positive
@@ -71,14 +71,14 @@ public:
   double get_distance(const State& state1, const State& state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 */
-  vector<Control> get_controls(const State& state1, const State& state2) const;
+  std::vector<Control> get_controls(const State& state1, const State& state2) const;
 
 private:
   /** \brief Pimpl Idiom: class that contains functions to compute the families  */
   class HCpmpm_Reeds_Shepp;
 
   /** \brief Pimpl Idiom: unique pointer on class with families  */
-  unique_ptr<HCpmpm_Reeds_Shepp> hcpmpm_reeds_shepp_;
+  std::unique_ptr<HCpmpm_Reeds_Shepp> hcpmpm_reeds_shepp_;
 
   /** \brief Parameter of a rs-circle */
   HC_CC_Circle_Param rs_circle_param_;
@@ -92,5 +92,7 @@ private:
   /** \brief Sine and cosine of mu */
   double sin_mu_, cos_mu_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp
+++ b/include/steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp
@@ -26,17 +26,13 @@
 #ifndef HCPMPM_REEDS_SHEPP_STATE_SPACE_HPP
 #define HCPMPM_REEDS_SHEPP_STATE_SPACE_HPP
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
-#include "hc_cc_state_space.hpp"
-#include "paths.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/hc_cc_state_space/paths.hpp
+++ b/include/steering_functions/hc_cc_state_space/paths.hpp
@@ -37,8 +37,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 class Path
 {
@@ -161,26 +161,28 @@ void reverse_control(Control &control);
 Control subtract_control(const Control &control1, const Control &control2);
 
 /** \brief Appends controls with 0 input */
-void empty_controls(vector<Control> &controls);
+void empty_controls(std::vector<Control> &controls);
 
 /** \brief Appends controls with a straight line */
-void straight_controls(const Configuration &q1, const Configuration &q2, vector<Control> &controls);
+void straight_controls(const Configuration &q1, const Configuration &q2, std::vector<Control> &controls);
 
 /** \brief Appends controls with a rs-turn */
-void rs_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, vector<Control> &controls);
+void rs_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, std::vector<Control> &controls);
 
 /** \brief Appends controls with a hc-turn */
-void hc_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, vector<Control> &controls);
+void hc_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, std::vector<Control> &controls);
 
 /** \brief Appends controls with an elementary path if one exists */
 bool cc_elementary_controls(const HC_CC_Circle &c, const Configuration &q, double delta, bool order,
-                            vector<Control> &controls);
+                            std::vector<Control> &controls);
 
 /** \brief Appends controls with a default cc-turn consisting of two clothoids and a circular arc */
 void cc_default_controls(const HC_CC_Circle &c, const Configuration &q, double delta, bool order,
-                         vector<Control> &controls);
+                         std::vector<Control> &controls);
 
 /** \brief Appends controls with a cc-turn */
-void cc_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, vector<Control> &controls);
+void cc_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order, std::vector<Control> &controls);
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/hc_cc_state_space/paths.hpp
+++ b/include/steering_functions/hc_cc_state_space/paths.hpp
@@ -26,16 +26,12 @@
 #ifndef PATHS_HPP
 #define PATHS_HPP
 
-#include <cassert>
-#include <iostream>
-#include <limits>
-#include <vector>
 #include <numeric>
+#include <vector>
 
-#include "configuration.hpp"
-#include "hc_cc_circle.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp
+++ b/include/steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp
@@ -70,8 +70,8 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
+namespace steering
+{
 
 /** \brief An SE(2) state space where distance is measured by the
     length of Reeds-Shepp curves.
@@ -107,7 +107,7 @@ public:
   public:
     /** \brief Constructor of the Reeds_Shepp_Path */
     Reeds_Shepp_Path(const Reeds_Shepp_Path_Segment_Type *type = reeds_shepp_path_type[0],
-                     double t = numeric_limits<double>::max(), double u = 0., double v = 0., double w = 0.,
+                     double t = std::numeric_limits<double>::max(), double u = 0., double v = 0., double w = 0.,
                      double x = 0.);
 
     double length() const
@@ -146,24 +146,24 @@ public:
   double get_distance(const State &state1, const State &state2) const;
 
   /** \brief Returns controls of the shortest path from state1 to state2 with curvature = kappa_ */
-  vector<Control> get_controls(const State &state1, const State &state2) const;
+  std::vector<Control> get_controls(const State &state1, const State &state2) const;
 
   /** \brief Returns shortest path from state1 to state2 with curvature = kappa_ */
-  vector<State> get_path(const State &state1, const State &state2) const;
+  std::vector<State> get_path(const State &state1, const State &state2) const;
 
   /** \brief Returns shortest path including covariances from state1 to state2 with curvature = kappa_ */
-  vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance &state1,
-                                                         const State &state2) const;
+  std::vector<State_With_Covariance> get_path_with_covariance(const State_With_Covariance &state1,
+                                                              const State &state2) const;
 
   /** \brief Returns integrated states given a start state and controls with curvature = kappa_ */
-  vector<State> integrate(const State &state, const vector<Control> &controls) const;
+  std::vector<State> integrate(const State &state, const std::vector<Control> &controls) const;
 
   /** \brief Returns integrated states including covariance given a start state and controls with curvature = kappa_ */
-  vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance &state,
-                                                          const vector<Control> &controls) const;
+  std::vector<State_With_Covariance> integrate_with_covariance(const State_With_Covariance &state,
+                                                               const std::vector<Control> &controls) const;
 
   /** \brief Returns interpolated state at distance t in [0,1] (percent of total path length with curvature = kappa_) */
-  State interpolate(const State &state, const vector<Control> &controls, double t) const;
+  State interpolate(const State &state, const std::vector<Control> &controls, double t) const;
 
   /** \brief Returns integrated state given a start state, a control, and an integration step */
   inline State integrate_ODE(const State &state, const Control &control, double integration_step) const;
@@ -181,5 +181,7 @@ private:
   /** \brief Extended Kalman Filter for uncertainty propagation */
   EKF ekf_;
 };
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp
+++ b/include/steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp
@@ -61,14 +61,11 @@
 #define __REEDS_SHEPP_STATE_SPACE_HPP_
 
 #include <cassert>
-#include <cmath>
-#include <iostream>
 #include <limits>
 #include <vector>
 
 #include "steering_functions/filter/ekf.hpp"
 #include "steering_functions/steering_functions.hpp"
-#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/include/steering_functions/steering_functions.hpp
+++ b/include/steering_functions/steering_functions.hpp
@@ -20,8 +20,9 @@
 #ifndef STEERING_FUNCTIONS_HPP
 #define STEERING_FUNCTIONS_HPP
 
-namespace steer
+namespace steering
 {
+
 /** \brief Description of a kinematic car's state */
 struct State
 {
@@ -111,6 +112,7 @@ struct Controller
   /** \brief Weight on heading error */
   double k3;
 };
-}
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/utilities/utilities.hpp
+++ b/include/steering_functions/utilities/utilities.hpp
@@ -32,14 +32,15 @@
 
 #include "fresnel.data"
 
-using namespace std;
-
 #define PI 3.1415926535897932384
 #define HALF_PI 1.5707963267948966192
 #define TWO_PI 6.2831853071795864770
 #define SQRT_PI 1.7724538509055160273
 #define SQRT_PI_INV 0.56418958354775628695
 #define SQRT_TWO_PI_INV 0.39894228040143267794
+
+namespace steering
+{
 
 const double epsilon = 1e-4;
 
@@ -112,5 +113,7 @@ void double_array_init(double array[], int size, double value);
 
 /** \brief Initialize an array with nullptr */
 void pointer_array_init(void *array[], int size);
+
+} // namespace steering
 
 #endif

--- a/include/steering_functions/utilities/utilities.hpp
+++ b/include/steering_functions/utilities/utilities.hpp
@@ -26,10 +26,6 @@
 #ifndef UTILITIES_HPP
 #define UTILITIES_HPP
 
-#include <cassert>
-#include <cmath>
-#include <iostream>
-
 #include "fresnel.data"
 
 #define PI 3.1415926535897932384

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>steering_functions</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>The steering_functions package</description>
 
   <maintainer email="holger.banzhaf@de.bosch.com">Holger Banzhaf</maintainer>

--- a/src/dubins_state_space/dubins_state_space.cpp
+++ b/src/dubins_state_space/dubins_state_space.cpp
@@ -59,7 +59,12 @@
 
 #include "steering_functions/dubins_state_space/dubins_state_space.hpp"
 
-namespace
+using namespace std;
+
+namespace steering
+{
+
+namespace /* helper */
 {
 const double DUBINS_EPS = 1e-6;
 const double DUBINS_ZERO = -1e-9;
@@ -208,7 +213,7 @@ Dubins_State_Space::Dubins_Path dubins(double d, double alpha, double beta)
     path = tmp;
   return path;
 }
-}
+} // namespace helper
 
 const Dubins_State_Space::Dubins_Path_Segment_Type Dubins_State_Space::dubins_path_type[6][3] = {
   { DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT },  { DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT },
@@ -220,7 +225,7 @@ Dubins_State_Space::Dubins_Path Dubins_State_Space::dubins(const State &state1, 
 {
   double dx = state2.x - state1.x, dy = state2.y - state1.y, th = atan2(dy, dx), d = sqrt(dx * dx + dy * dy) * kappa_;
   double alpha = twopify(state1.theta - th), beta = twopify(state2.theta - th);
-  return ::dubins(d, alpha, beta);
+  return steering::dubins(d, alpha, beta);
 }
 
 void Dubins_State_Space::set_filter_parameters(const Motion_Noise &motion_noise,
@@ -493,3 +498,5 @@ inline State Dubins_State_Space::integrate_ODE(const State &state, const Control
   }
   return state_next;
 }
+
+} // namespace steering

--- a/src/dubins_state_space/dubins_state_space.cpp
+++ b/src/dubins_state_space/dubins_state_space.cpp
@@ -57,7 +57,11 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <algorithm>
+#include <cmath>
+
 #include "steering_functions/dubins_state_space/dubins_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/filter/ekf.cpp
+++ b/src/filter/ekf.cpp
@@ -17,6 +17,9 @@
 
 #include "steering_functions/filter/ekf.hpp"
 
+namespace steering
+{
+
 EKF::EKF()
 {
   I_ = Matrix3d::Identity();
@@ -250,3 +253,5 @@ void EKF::update(const State_With_Covariance &state_pred, State_With_Covariance 
   eigen_to_covariance(Lambda_corr, state_corr.Lambda);
   eigen_to_covariance(Sigma_corr + Lambda_corr, state_corr.covariance);
 }
+
+} // namespace steering

--- a/src/filter/ekf.cpp
+++ b/src/filter/ekf.cpp
@@ -15,7 +15,10 @@
 *  limitations under the License.
 * *********************************************************************/
 
+#include <cmath>
+
 #include "steering_functions/filter/ekf.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 namespace steering
 {

--- a/src/hc_cc_state_space/cc00_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc00_dubins_state_space.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 class CC00_Dubins_State_Space::CC00_Dubins
 {
 private:
@@ -520,3 +525,5 @@ vector<Control> CC00_Dubins_State_Space::get_controls(const State &state1, const
   delete p;
   return cc_dubins_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/cc00_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc00_dubins_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/cc00_dubins_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/cc00_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/cc00_reeds_shepp_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/cc00_reeds_shepp_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 #define CC_REGULAR false
 

--- a/src/hc_cc_state_space/cc00_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/cc00_reeds_shepp_state_space.cpp
@@ -27,6 +27,11 @@
 
 #define CC_REGULAR false
 
+using namespace std;
+
+namespace steering
+{
+
 class CC00_Reeds_Shepp_State_Space::CC00_Reeds_Shepp
 {
 private:
@@ -1771,3 +1776,5 @@ vector<Control> CC00_Reeds_Shepp_State_Space::get_controls(const State &state1, 
   delete p;
   return cc_rs_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/cc0pm_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc0pm_dubins_state_space.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 class CC0pm_Dubins_State_Space::CC0pm_Dubins
 {
 private:
@@ -537,3 +542,5 @@ vector<Control> CC0pm_Dubins_State_Space::get_controls(const State &state1, cons
   delete p;
   return cc_dubins_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/cc0pm_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc0pm_dubins_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/cc0pm_dubins_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/cc_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc_dubins_state_space.cpp
@@ -15,7 +15,11 @@
 *  limitations under the License.
 * *********************************************************************/
 
+#include <algorithm>
+#include <cmath>
+
 #include "steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/cc_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/cc_dubins_state_space.cpp
@@ -17,6 +17,11 @@
 
 #include "steering_functions/hc_cc_state_space/cc_dubins_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 CC_Dubins_State_Space::CC_Dubins_State_Space(double kappa, double sigma, double discretization, bool forwards)
   : HC_CC_State_Space(kappa, sigma, discretization)
   , forwards_(forwards)
@@ -210,3 +215,5 @@ vector<Control> CC_Dubins_State_Space::get_controls(const State &state1, const S
 
   return cc_dubins_controls_distance_pairs[0].first;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/ccpm0_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/ccpm0_dubins_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/ccpm0_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/ccpm0_dubins_state_space.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/ccpm0_dubins_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 class CCpm0_Dubins_State_Space::CCpm0_Dubins
 {
 private:
@@ -536,3 +541,5 @@ vector<Control> CCpm0_Dubins_State_Space::get_controls(const State &state1, cons
   delete p;
   return cc_dubins_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/ccpmpm_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/ccpmpm_dubins_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/ccpmpm_dubins_state_space.cpp
+++ b/src/hc_cc_state_space/ccpmpm_dubins_state_space.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/ccpmpm_dubins_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 class CCpmpm_Dubins_State_Space::CCpmpm_Dubins
 {
 private:
@@ -689,3 +694,5 @@ vector<Control> CCpmpm_Dubins_State_Space::get_controls(const State &state1, con
   delete p;
   return cc_dubins_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/configuration.cpp
+++ b/src/hc_cc_state_space/configuration.cpp
@@ -23,7 +23,11 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <iostream>
+
 #include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/configuration.cpp
+++ b/src/hc_cc_state_space/configuration.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/configuration.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 Configuration::Configuration(double _x, double _y, double _theta, double _kappa)
 {
   x = _x;
@@ -65,3 +70,5 @@ bool configuration_equal(const Configuration &q1, const Configuration &q2)
     return false;
   return true;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hc00_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc00_reeds_shepp_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 #define CC_REGULAR false
 

--- a/src/hc_cc_state_space/hc00_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc00_reeds_shepp_state_space.cpp
@@ -27,6 +27,11 @@
 
 #define CC_REGULAR false
 
+using namespace std;
+
+namespace steering
+{
+
 class HC00_Reeds_Shepp_State_Space::HC00_Reeds_Shepp
 {
 private:
@@ -1852,3 +1857,5 @@ vector<Control> HC00_Reeds_Shepp_State_Space::get_controls(const State &state1, 
   delete p;
   return hc_rs_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hc0pm_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc0pm_reeds_shepp_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hc0pm_reeds_shepp_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 #define HC_REGULAR false
 #define CC_REGULAR false

--- a/src/hc_cc_state_space/hc0pm_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc0pm_reeds_shepp_state_space.cpp
@@ -28,6 +28,11 @@
 #define HC_REGULAR false
 #define CC_REGULAR false
 
+using namespace std;
+
+namespace steering
+{
+
 class HC0pm_Reeds_Shepp_State_Space::HC0pm_Reeds_Shepp
 {
 private:
@@ -1879,3 +1884,5 @@ vector<Control> HC0pm_Reeds_Shepp_State_Space::get_controls(const State &state1,
   delete p;
   return hc_rs_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hc_cc_circle.cpp
+++ b/src/hc_cc_state_space/hc_cc_circle.cpp
@@ -23,7 +23,13 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/hc_cc_circle.cpp
+++ b/src/hc_cc_state_space/hc_cc_circle.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/hc_cc_circle.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 void HC_CC_Circle_Param::set_param(double _kappa, double _sigma, double _radius, double _mu, double _sin_mu,
                                    double _cos_mu, double _delta_min)
 {
@@ -325,3 +330,5 @@ bool configuration_on_hc_cc_circle(const HC_CC_Circle &c, const Configuration &q
   angle = twopify(angle);
   return fabs(q.theta - angle) < get_epsilon();
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hc_cc_state_space.cpp
+++ b/src/hc_cc_state_space/hc_cc_state_space.cpp
@@ -17,6 +17,11 @@
 
 #include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 HC_CC_State_Space::HC_CC_State_Space(double kappa, double sigma, double discretization)
   : kappa_(kappa), sigma_(sigma), discretization_(discretization)
 {
@@ -300,3 +305,5 @@ inline State HC_CC_State_Space::integrate_ODE(const State &state, const Control 
   }
   return state_next;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hc_cc_state_space.cpp
+++ b/src/hc_cc_state_space/hc_cc_state_space.cpp
@@ -15,7 +15,10 @@
 *  limitations under the License.
 ***********************************************************************/
 
+#include <cmath>
+
 #include "steering_functions/hc_cc_state_space/hc_cc_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/hc_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc_reeds_shepp_state_space.cpp
@@ -15,7 +15,12 @@
 *  limitations under the License.
 * *********************************************************************/
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/hc_cc_state_space/hc_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hc_reeds_shepp_state_space.cpp
@@ -17,6 +17,11 @@
 
 #include "steering_functions/hc_cc_state_space/hc_reeds_shepp_state_space.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 HC_Reeds_Shepp_State_Space::HC_Reeds_Shepp_State_Space(double kappa, double sigma, double discretization)
   : HC_CC_State_Space(kappa, sigma, discretization)
   , hc00_reeds_shepp_state_space_(kappa, sigma, discretization)
@@ -204,3 +209,5 @@ vector<Control> HC_Reeds_Shepp_State_Space::get_controls(const State &state1, co
 
   return hc_rs_controls_distance_pairs[0].first;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hcpm0_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hcpm0_reeds_shepp_state_space.cpp
@@ -28,6 +28,11 @@
 #define HC_REGULAR false
 #define CC_REGULAR false
 
+using namespace std;
+
+namespace steering
+{
+
 class HCpm0_Reeds_Shepp_State_Space::HCpm0_Reeds_Shepp
 {
 private:
@@ -1877,3 +1882,5 @@ vector<Control> HCpm0_Reeds_Shepp_State_Space::get_controls(const State &state1,
   delete p;
   return hc_rs_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hcpm0_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hcpm0_reeds_shepp_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 #define HC_REGULAR false
 #define CC_REGULAR false

--- a/src/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.cpp
@@ -28,6 +28,11 @@
 #define HC_REGULAR false
 #define CC_REGULAR false
 
+using namespace std;
+
+namespace steering
+{
+
 class HCpmpm_Reeds_Shepp_State_Space::HCpmpm_Reeds_Shepp
 {
 private:
@@ -1926,3 +1931,5 @@ vector<Control> HCpmpm_Reeds_Shepp_State_Space::get_controls(const State &state1
   delete p;
   return hc_rs_controls;
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.cpp
+++ b/src/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.cpp
@@ -23,7 +23,12 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cmath>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp"
+#include "steering_functions/hc_cc_state_space/configuration.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 #define HC_REGULAR false
 #define CC_REGULAR false

--- a/src/hc_cc_state_space/paths.cpp
+++ b/src/hc_cc_state_space/paths.cpp
@@ -25,6 +25,11 @@
 
 #include "steering_functions/hc_cc_state_space/paths.hpp"
 
+using namespace std;
+
+namespace steering
+{
+
 Path::Path(const Configuration &_start, const Configuration &_end, double _kappa, double _sigma, double _length)
 {
   start = _start;
@@ -447,3 +452,5 @@ void cc_turn_controls(const HC_CC_Circle &c, const Configuration &q, bool order,
     return;
   }
 }
+
+} // namespace steering

--- a/src/hc_cc_state_space/paths.cpp
+++ b/src/hc_cc_state_space/paths.cpp
@@ -23,7 +23,13 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <limits>
+
 #include "steering_functions/hc_cc_state_space/paths.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
+++ b/src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
@@ -59,7 +59,12 @@
 
 #include "steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp"
 
-namespace
+using namespace std;
+
+namespace steering
+{
+
+namespace /* helper */
 {
 // The comments, variable names, etc. use the nomenclature from the Reeds & Shepp paper.
 const double RS_EPS = 1e-6;
@@ -480,7 +485,7 @@ Reeds_Shepp_State_Space::Reeds_Shepp_Path reeds_shepp(double x, double y, double
   CCSCC(x, y, phi, path);
   return path;
 }
-}
+} // namespace helper
 
 const Reeds_Shepp_State_Space::Reeds_Shepp_Path_Segment_Type Reeds_Shepp_State_Space::reeds_shepp_path_type[18][5] = {
   { RS_LEFT, RS_RIGHT, RS_LEFT, RS_NOP, RS_NOP },         // 0
@@ -521,7 +526,7 @@ Reeds_Shepp_State_Space::Reeds_Shepp_Path Reeds_Shepp_State_Space::reeds_shepp(c
   double dx = state2.x - state1.x, dy = state2.y - state1.y, dth = state2.theta - state1.theta;
   double c = cos(state1.theta), s = sin(state1.theta);
   double x = c * dx + s * dy, y = -s * dx + c * dy;
-  return ::reeds_shepp(x * kappa_, y * kappa_, dth);
+  return steering::reeds_shepp(x * kappa_, y * kappa_, dth);
 }
 
 void Reeds_Shepp_State_Space::set_filter_parameters(const Motion_Noise &motion_noise,
@@ -783,3 +788,5 @@ inline State Reeds_Shepp_State_Space::integrate_ODE(const State &state, const Co
   }
   return state_next;
 }
+
+} // namespace steering

--- a/src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
+++ b/src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
@@ -57,7 +57,10 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <cmath>
+
 #include "steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
 

--- a/src/steering_functions_node.cpp
+++ b/src/steering_functions_node.cpp
@@ -53,6 +53,7 @@
 #define random(lower, upper) (rand() * (upper - lower) / RAND_MAX + lower)
 
 using namespace std;
+using namespace steering;
 
 class PathClass
 {

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -25,6 +25,9 @@
 
 #include "steering_functions/utilities/utilities.hpp"
 
+namespace steering
+{
+
 double get_epsilon()
 {
   return epsilon;
@@ -239,3 +242,5 @@ void pointer_array_init(void *array[], int size)
     array[i] = nullptr;
   }
 }
+
+} // namespace steering

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -23,6 +23,9 @@
 *  directory of this source tree.
 **********************************************************************/
 
+#include <cassert>
+#include <cmath>
+
 #include "steering_functions/utilities/utilities.hpp"
 
 namespace steering

--- a/test/fresnel_test.cpp
+++ b/test/fresnel_test.cpp
@@ -15,6 +15,7 @@
 *  limitations under the License.
 * *********************************************************************/
 
+#include <cmath>
 #include <gtest/gtest.h>
 
 #include "steering_functions/utilities/utilities.hpp"

--- a/test/fresnel_test.cpp
+++ b/test/fresnel_test.cpp
@@ -20,6 +20,7 @@
 #include "steering_functions/utilities/utilities.hpp"
 
 using namespace std;
+using namespace steering;
 
 #define EPS_FRESNEL 1e-14
 

--- a/test/hc_cc_circle_test.cpp
+++ b/test/hc_cc_circle_test.cpp
@@ -24,14 +24,14 @@
 #include "steering_functions/hc_cc_state_space/paths.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
-
 #define EPS_DISTANCE 0.01    // [m]
 #define EPS_KAPPA 1e-6       // [1/m]
 #define EPS_SIGMA 1e-6       // [1/m^2]
 #define KAPPA 1.0            // [1/m]
 #define DISCRETIZATION 0.05  // [m]
+
+using namespace std;
+using namespace steering;
 
 class Test_HC_CC_State_Space : public HC_CC_State_Space
 {

--- a/test/jacobian_test.cpp
+++ b/test/jacobian_test.cpp
@@ -23,9 +23,6 @@
 #include "steering_functions/steering_functions.hpp"
 #include "steering_functions/utilities/utilities.hpp"
 
-using namespace std;
-using namespace steer;
-
 #define EPS_JACOBI 1e-4                  // [-]
 #define EPS_PERTURB 1e-7                 // [-]
 #define SAMPLES 1e6                      // [-]
@@ -37,6 +34,9 @@ using namespace steer;
 #define OPERATING_REGION_SIGMA 2.0       // [1/m^2]
 #define random(lower, upper) (rand() * (upper - lower) / RAND_MAX + lower)
 #define random_boolean() rand() % 2
+
+using namespace std;
+using namespace steering;
 
 typedef Eigen::Matrix<double, 2, 2> Matrix2d;
 typedef Eigen::Matrix<double, 3, 3> Matrix3d;

--- a/test/steering_functions_test.cpp
+++ b/test/steering_functions_test.cpp
@@ -35,9 +35,6 @@
 #include "steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp"
 #include "steering_functions/steering_functions.hpp"
 
-using namespace std;
-using namespace steer;
-
 #define EPS_DISTANCE 0.01                // [m]
 #define EPS_YAW 0.01                     // [rad]
 #define EPS_KAPPA 1e-6                   // [1/m]
@@ -50,6 +47,9 @@ using namespace steer;
 #define OPERATING_REGION_THETA 2 * M_PI  // [rad]
 #define random(lower, upper) (rand() * (upper - lower) / RAND_MAX + lower)
 #define random_boolean() rand() % 2
+
+using namespace std;
+using namespace steering;
 
 State get_random_state()
 {

--- a/test/steering_functions_test.cpp
+++ b/test/steering_functions_test.cpp
@@ -33,6 +33,7 @@
 #include "steering_functions/hc_cc_state_space/hcpm0_reeds_shepp_state_space.hpp"
 #include "steering_functions/hc_cc_state_space/hcpmpm_reeds_shepp_state_space.hpp"
 #include "steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp"
+#include "steering_functions/utilities/utilities.hpp"
 #include "steering_functions/steering_functions.hpp"
 
 #define EPS_DISTANCE 0.01                // [m]

--- a/test/timing_test.cpp
+++ b/test/timing_test.cpp
@@ -37,9 +37,6 @@
 #include "steering_functions/reeds_shepp_state_space/reeds_shepp_state_space.hpp"
 #include "steering_functions/steering_functions.hpp"
 
-using namespace std;
-using namespace steer;
-
 #define EPS_KAPPA 1e-3                   // [1/m]
 #define KAPPA 1.0                        // [1/m]
 #define SIGMA 1.0                        // [1/m^2]
@@ -59,6 +56,9 @@ using namespace steer;
 #define K2 0.25                          // [-]
 #define K3 1.0                           // [-]
 #define random(lower, upper) (rand() * (upper - lower) / RAND_MAX + lower)
+
+using namespace std;
+using namespace steering;
 
 struct Statistic
 {


### PR DESCRIPTION
As discussed in #14 (a long time ago), I added everything in this library into a namespace and changed the namespace name from 'steer' to 'steering' at the same time. I also removed 'using namespace' from header files as this is bad practice in C++ (pollutes the namespace of everybody including the header file). I also cleaned up the includes directives while I was at it.

A version bump is needed due to these breaking changes. Should I do it in this PR or do you that yourself?