### PR TITLE
Fix complie warning about CMAKE_PROJECT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(steering_functions)
 
 ## Compile as C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
All active ROS distributions support 3.0.2.

Similar to this: https://answers.ros.org/question/361001/how-to-fix-unstable-build-on-buildfarm-for-noetic-because-of-cmp0048/