### PR TITLE
CMake project config which suports non-ROS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ set(PROJECT_VERSION 0.2.0)
 option(BUILD_WITH_ROS "Build with ROS support" ON)
 
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
 find_package(Eigen3 REQUIRED)
 
 if(BUILD_WITH_ROS)
@@ -52,7 +51,7 @@ target_link_libraries(${PROJECT_NAME}
 
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}Targets
+    EXPORT ${PROJECT_NAME}-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -64,7 +63,7 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
-install(EXPORT ${PROJECT_NAME}Targets
+install(EXPORT ${PROJECT_NAME}-targets
     FILE "${PROJECT_NAME}-targets.cmake"
     NAMESPACE steering_functions::
     DESTINATION "lib/cmake/${PROJECT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,8 @@ project(steering_functions)
 
 set(PROJECT_VERSION 0.1.1)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 option(BUILD_SHARED_LIBS "Build as shared library" OFF)
-option(BUILD_WITH_ROS "Buidl with ROS support" ON)
+option(BUILD_WITH_ROS "Build with ROS support" ON)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -28,7 +25,6 @@ if(BUILD_WITH_ROS)
     catkin_package(
         INCLUDE_DIRS include
         LIBRARIES steering_functions
-        #  CATKIN_DEPENDS other_catkin_pkg
         DEPENDS EIGEN3
     )
 endif()
@@ -104,8 +100,6 @@ if(BUILD_WITH_ROS)
 
     install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-        #   FILES_MATCHING PATTERN "*.h"
-        #   PATTERN ".svn" EXCLUDE
     )
 
     install(DIRECTORY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,19 +60,19 @@ install(TARGETS ${PROJECT_NAME}
 )
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    ${PROJECT_NAME}ConfigVersion.cmake
+    ${PROJECT_NAME}-config-version.cmake
     COMPATIBILITY AnyNewerVersion
 )
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 install(EXPORT ${PROJECT_NAME}Targets
-    FILE "${PROJECT_NAME}Targets.cmake"
+    FILE "${PROJECT_NAME}-targets.cmake"
     NAMESPACE steering_functions::
     DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
 install(
     FILES
-        "${PROJECT_NAME}Config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        "${PROJECT_NAME}-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
     DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
 
@@ -106,7 +106,6 @@ if(BUILD_WITH_ROS)
         launch
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     )
-
 
     if(CATKIN_ENABLE_TESTING)
         ## Add gtest based cpp test target and link libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,235 +1,150 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(steering_functions)
 
+set(PROJECT_VERSION 0.1.1)
+
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  geometry_msgs
-  nav_msgs
-  visualization_msgs
-  roslib
-  costmap_2d
-  tf
-  cmake_modules
-)
+option(BUILD_SHARED_LIBS "Build as shared library" OFF)
+option(BUILD_WITH_ROS "Buidl with ROS support" ON)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 find_package(Eigen3 REQUIRED)
 
+if(BUILD_WITH_ROS)
+    find_package(catkin REQUIRED COMPONENTS
+        roscpp
+        geometry_msgs
+        nav_msgs
+        visualization_msgs
+        roslib
+        costmap_2d
+        tf
+        cmake_modules
+    )
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES steering_functions
-#  CATKIN_DEPENDS other_catkin_pkg
-  DEPENDS EIGEN3
-)
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-)
+    catkin_package(
+        INCLUDE_DIRS include
+        LIBRARIES steering_functions
+        #  CATKIN_DEPENDS other_catkin_pkg
+        DEPENDS EIGEN3
+    )
+endif()
 
 ## Get all source files
 file(GLOB SRC_HC_CC_SS src/hc_cc_state_space/*.cpp)
-set(SRC_FILES
+
+add_library(${PROJECT_NAME}
     src/dubins_state_space/dubins_state_space.cpp
     src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
     src/utilities/utilities.cpp
     src/filter/ekf.cpp
-    ${SRC_HC_CC_SS})
-
-## Declare a C++ library
-add_library(${PROJECT_NAME} ${SRC_FILES})
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp ${SRC_FILES})
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}_node
-  ${catkin_LIBRARIES}
+    ${SRC_HC_CC_SS}
 )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-## Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        Eigen3::Eigen
 )
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY
-   config
-   launch
-   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${PROJECT_NAME}ConfigVersion.cmake
+    COMPATIBILITY AnyNewerVersion
+)
+install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
+install(EXPORT ${PROJECT_NAME}Targets
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE steering_functions::
+    DESTINATION "lib/cmake/${PROJECT_NAME}"
+)
+install(
+    FILES
+        "${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
 
-#############
-## Testing ##
-#############
+if(BUILD_WITH_ROS)
+    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
 
-if(CATKIN_ENABLE_TESTING)
-  ## Add gtest based cpp test target and link libraries
-  catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
-  if(TARGET steering_functions_test)
-    target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-  endif()
+    target_link_libraries(${PROJECT_NAME}_node
+        PRIVATE
+            steering_functions
+            Eigen3::Eigen
+            ${catkin_LIBRARIES}
+    )
 
-  catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
-  if(TARGET fresnel_test)
-    target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-  endif()
+    target_include_directories(${PROJECT_NAME}_node
+        PRIVATE
+            ${catkin_INCLUDE_DIRS}
+    )
 
-  catkin_add_gtest(timing_test test/timing_test.cpp)
-  if(TARGET timing_test)
-    target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-  endif()
+    install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
-  catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
-  if(TARGET jacobian_test)
-    target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-  endif()
+    install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        #   FILES_MATCHING PATTERN "*.h"
+        #   PATTERN ".svn" EXCLUDE
+    )
 
-  catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
-  if(TARGET hc_cc_circle_test)
-    target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-  endif()
+    install(DIRECTORY
+        config
+        launch
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+    )
+
+
+    if(CATKIN_ENABLE_TESTING)
+        ## Add gtest based cpp test target and link libraries
+        catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
+        if(TARGET steering_functions_test)
+            target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+            target_include_directories(steering_functions_test PRIVATE ${catkin_INCLUDE_DIRS})
+        endif()
+
+        catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
+        if(TARGET fresnel_test)
+            target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+            target_include_directories(fresnel_test PRIVATE ${catkin_INCLUDE_DIRS})
+        endif()
+
+        catkin_add_gtest(timing_test test/timing_test.cpp)
+        if(TARGET timing_test)
+            target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+            target_include_directories(timing_test PRIVATE ${catkin_INCLUDE_DIRS})
+        endif()
+
+        catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
+        if(TARGET jacobian_test)
+            target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+            target_include_directories(jacobian_test PRIVATE ${catkin_INCLUDE_DIRS})
+        endif()
+
+        catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
+        if(TARGET hc_cc_circle_test)
+            target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+            target_include_directories(hc_cc_circle_test PRIVATE ${catkin_INCLUDE_DIRS})
+        endif()
+    endif()
 endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(steering_functions)
 
 set(PROJECT_VERSION 0.1.1)
 
-option(BUILD_SHARED_LIBS "Build as shared library" OFF)
 option(BUILD_WITH_ROS "Build with ROS support" ON)
 
 ## System dependencies are found with CMake's conventions
@@ -31,14 +30,15 @@ endif()
 
 ## Get all source files
 file(GLOB SRC_HC_CC_SS src/hc_cc_state_space/*.cpp)
-
-add_library(${PROJECT_NAME}
+set(SRC_FILES
     src/dubins_state_space/dubins_state_space.cpp
     src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
     src/utilities/utilities.cpp
     src/filter/ekf.cpp
     ${SRC_HC_CC_SS}
 )
+
+add_library(${PROJECT_NAME} ${SRC_FILES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -78,17 +78,17 @@ install(
 )
 
 if(BUILD_WITH_ROS)
-    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
+    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp ${SRC_FILES})
 
     target_link_libraries(${PROJECT_NAME}_node
         PRIVATE
-            steering_functions
             Eigen3::Eigen
             ${catkin_LIBRARIES}
     )
 
     target_include_directories(${PROJECT_NAME}_node
         PRIVATE
+            include
             ${catkin_INCLUDE_DIRS}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,15 +30,14 @@ endif()
 
 ## Get all source files
 file(GLOB SRC_HC_CC_SS src/hc_cc_state_space/*.cpp)
-set(SRC_FILES
+
+add_library(${PROJECT_NAME}
     src/dubins_state_space/dubins_state_space.cpp
     src/reeds_shepp_state_space/reeds_shepp_state_space.cpp
     src/utilities/utilities.cpp
     src/filter/ekf.cpp
     ${SRC_HC_CC_SS}
 )
-
-add_library(${PROJECT_NAME} ${SRC_FILES})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -78,17 +77,17 @@ install(
 )
 
 if(BUILD_WITH_ROS)
-    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp ${SRC_FILES})
+    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
 
     target_link_libraries(${PROJECT_NAME}_node
         PRIVATE
+            steering_functions
             Eigen3::Eigen
             ${catkin_LIBRARIES}
     )
 
     target_include_directories(${PROJECT_NAME}_node
         PRIVATE
-            include
             ${catkin_INCLUDE_DIRS}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(steering_functions)
 
-set(PROJECT_VERSION 0.1.1)
+set(PROJECT_VERSION 0.2.0)
 
 option(BUILD_WITH_ROS "Build with ROS support" ON)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ To launch a demo of the package, execute
 
 To link this library with another [ROS] package, add these lines to your package's CMakeLists.txt
 
-    add_compile_options(-std=c++11)
     find_package(catkin REQUIRED COMPONENTS
       steering_functions
     )

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ To link this library to another C++ library/executable, add these lines to your 
 
 Now the steering functions can be used in your project by including the appropriate header, e.g.
 
-      #include <steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp>
+    #include <steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp>
+
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To build this package from source, clone it and compile it in *Release* mode (an
     cmake --build . --parallel
     cmake --install .
 
-A shared library version (libsteering_functions.so) can be built instead of the default static library (libsteering_function.a) by
+A shared library (libsteering_functions.so) can be built instead of the default static library (libsteering_functions.a) by
 
     cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_ROS=OFF -DBUILD_SHARED_LIBS=ON
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The source code in this package is released under the Apache-2.0 License. For fu
 The [3rdparty-licenses.txt](3rd-party-licenses.txt) contains a list of other open source components included in this package.
 
 
-## Installation & Usage
+## Installation & Usage as a ROS package
 
 ### Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
@@ -116,6 +116,38 @@ To run a single test, e.g. the timing test, execute
 
     cd catkin_ws/devel/lib/steering_functions
     ./timing_test
+
+
+## Installation & Usage as a C++ library (without ROS)
+
+### Dependencies
+This package depends on the linear algebra library [Eigen], which can be installed by
+
+    sudo apt-get install libeigen3-dev
+
+### Building
+
+To build this package from source, clone it and compile it in *Release* mode (and without ROS) according to
+
+    git clone https://github.com/hbanzhaf/steering_functions.git
+    cd steering_functions/
+    mkdir build && cd build/
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_ROS=OFF
+    cmake --build . --parallel
+    cmake --install .
+
+A shared library version (libsteering_functions.so) can be built instead of the default static library (libsteering_function.a) by
+
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_ROS=OFF -DBUILD_SHARED_LIBS=ON
+
+### Linking
+
+To link this library to another C++ library/executable, add these lines to your CMakeLists.txt
+
+    find_package(steering_functions CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME}
+      steering_functions::steering_functions
+    )
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To run a single test, e.g. the timing test, execute
     ./timing_test
 
 
-## Installation & Usage as a C++ library (without ROS)
+## Installation & Usage as a standalone library
 
 ### Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
@@ -126,7 +126,7 @@ This package depends on the linear algebra library [Eigen], which can be install
 
 ### Building
 
-To build this package from source, clone it and compile it in *Release* mode (and without ROS) according to
+To build this package from source, clone it and compile it in *Release* mode without ROS support according to
 
     git clone https://github.com/hbanzhaf/steering_functions.git
     cd steering_functions/
@@ -147,6 +147,10 @@ To link this library to another C++ library/executable, add these lines to your 
     target_link_libraries(${PROJECT_NAME}
       steering_functions::steering_functions
     )
+
+Now the steering functions can be used in your project by including the appropriate header, e.g.
+
+      #include <steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp>
 
 
 ## Documentation

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>steering_functions</name>
-  <version>0.1.1</version>
+  <version>0.2.0</version>
   <description>The steering_functions package</description>
 
   <maintainer email="holger.banzhaf@de.bosch.com">Holger Banzhaf</maintainer>

--- a/steering_functions-config.cmake
+++ b/steering_functions-config.cmake
@@ -4,4 +4,4 @@ include(CMakeFindDependencyMacro)
 find_dependency(Eigen3 REQUIRED)
 
 # Add the targets file
-include("${CMAKE_CURRENT_LIST_DIR}/steering_functionsTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/steering_functions-targets.cmake")

--- a/steering_functionsConfig.cmake
+++ b/steering_functionsConfig.cmake
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+
+# Same syntax as find_package
+find_dependency(Eigen3 REQUIRED)
+
+# Add the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/steering_functionsTargets.cmake")


### PR DESCRIPTION
Back again this year with a PR to my issue #16 from last year.

It installs and works as expected with a plain non-ROS build (pure C++ lib).

I also tested with ROS Melodic; the launch file, tests and using it in another ROS package.
(However, I'm not that experienced with ROS so you should check it ourselves that it installs and everything as expected.)

The pure C++ lib part of the CMake is mostly according to modern CMake best practices, the ROS part is just adopted from the original configuration.
The if statement with BUILD_WITH_ROS was needed twice since the catkin_package() was needed before add_library().

I guess a version bump is needed if this is merged. What version do you want?

It would be nice if @Timple also could take a look at it.