### PR TITLE
Port package partially to ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,6 @@ if(BUILD_WITH_ROS)
             target_link_libraries(hc_cc_circle_test ${PROJECT_NAME})
         endif()
 
-        ament_package()
+        # This package manages it's own package-config.cmake file, so its build_type is cmake and we don't call ament_package()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.8)
 project(steering_functions)
 
 set(PROJECT_VERSION 0.2.0)
@@ -7,24 +7,32 @@ option(BUILD_WITH_ROS "Build with ROS support" ON)
 
 ## System dependencies are found with CMake's conventions
 find_package(Eigen3 REQUIRED)
+message(STATUS "BUILD_WITH_ROS: ${BUILD_WITH_ROS}")
 
 if(BUILD_WITH_ROS)
-    find_package(catkin REQUIRED COMPONENTS
-        roscpp
-        geometry_msgs
-        nav_msgs
-        visualization_msgs
-        roslib
-        costmap_2d
-        tf
-        cmake_modules
-    )
+    set(ROS_VERSION $ENV{ROS_VERSION})
+    message(STATUS "ROS_VERSION: '${ROS_VERSION}'")
+    if(${ROS_VERSION} EQUAL 1)
+        find_package(catkin REQUIRED COMPONENTS
+            roscpp
+            geometry_msgs
+            nav_msgs
+            visualization_msgs
+            roslib
+            costmap_2d
+            tf
+            cmake_modules
+        )
 
-    catkin_package(
-        INCLUDE_DIRS include
-        LIBRARIES steering_functions
-        DEPENDS EIGEN3
-    )
+        catkin_package(
+            INCLUDE_DIRS include
+            LIBRARIES steering_functions
+            DEPENDS EIGEN3
+        )
+    elseif(${ROS_VERSION} EQUAL 2)
+        find_package(ament_cmake REQUIRED)
+        find_package(ament_cmake_ros REQUIRED)
+    endif()
 endif()
 
 ## Get all source files
@@ -66,76 +74,98 @@ install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 install(EXPORT ${PROJECT_NAME}-targets
     FILE "${PROJECT_NAME}-targets.cmake"
     NAMESPACE steering_functions::
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "share/${PROJECT_NAME}/cmake"
 )
 install(
     FILES
         "${PROJECT_NAME}-config.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "share/${PROJECT_NAME}/cmake"
 )
 
 if(BUILD_WITH_ROS)
-    add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
+    if(${ROS_VERSION} EQUAL 1)
+        add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
 
-    target_link_libraries(${PROJECT_NAME}_node
-        PRIVATE
-            steering_functions
-            Eigen3::Eigen
-            ${catkin_LIBRARIES}
-    )
+        target_link_libraries(${PROJECT_NAME}_node
+            PRIVATE
+                steering_functions
+                Eigen3::Eigen
+                ${catkin_LIBRARIES}
+        )
 
-    target_include_directories(${PROJECT_NAME}_node
-        PRIVATE
-            ${catkin_INCLUDE_DIRS}
-    )
+        target_include_directories(${PROJECT_NAME}_node
+            PRIVATE
+                ${catkin_INCLUDE_DIRS}
+        )
 
-    install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-    )
+        install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )
 
-    install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-    )
+        install(DIRECTORY include/${PROJECT_NAME}/
+            DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        )
 
-    install(DIRECTORY
-        config
-        launch
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-    )
+        install(DIRECTORY
+            config
+            launch
+            DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        )
 
-    if(CATKIN_ENABLE_TESTING)
-        ## Add gtest based cpp test target and link libraries
-        catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
-        if(TARGET steering_functions_test)
-            target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-            target_include_directories(steering_functions_test PRIVATE ${catkin_INCLUDE_DIRS})
+        if(CATKIN_ENABLE_TESTING)
+            ## Add gtest based cpp test target and link libraries
+            catkin_add_gtest(steering_functions_test test/steering_functions_test.cpp)
+            if(TARGET steering_functions_test)
+                target_link_libraries(steering_functions_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+                target_include_directories(steering_functions_test PRIVATE ${catkin_INCLUDE_DIRS})
+            endif()
+
+            catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
+            if(TARGET fresnel_test)
+                target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+                target_include_directories(fresnel_test PRIVATE ${catkin_INCLUDE_DIRS})
+            endif()
+
+            catkin_add_gtest(timing_test test/timing_test.cpp)
+            if(TARGET timing_test)
+                target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+                target_include_directories(timing_test PRIVATE ${catkin_INCLUDE_DIRS})
+            endif()
+
+            catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
+            if(TARGET jacobian_test)
+                target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+                target_include_directories(jacobian_test PRIVATE ${catkin_INCLUDE_DIRS})
+            endif()
+
+            catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
+            if(TARGET hc_cc_circle_test)
+                target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+                target_include_directories(hc_cc_circle_test PRIVATE ${catkin_INCLUDE_DIRS})
+            endif()
+        endif()
+    elseif(${ROS_VERSION} EQUAL 2)
+        if(BUILD_TESTING)
+            find_package(ament_cmake_gtest)
+            ament_add_gtest(steering_functions_test test/steering_functions_test.cpp TIMEOUT 240)
+            target_link_libraries(steering_functions_test ${PROJECT_NAME})
+
+            ament_add_gtest(fresnel_test test/fresnel_test.cpp)
+            target_link_libraries(fresnel_test ${PROJECT_NAME})
+
+            # ament_add_gtest(timing_test test/timing_test.cpp)
+            # target_link_libraries(timing_test ${PROJECT_NAME})
+
+            ament_add_gtest(jacobian_test test/jacobian_test.cpp)
+            target_link_libraries(jacobian_test ${PROJECT_NAME})
+
+            ament_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
+            target_link_libraries(hc_cc_circle_test ${PROJECT_NAME})
         endif()
 
-        catkin_add_gtest(fresnel_test test/fresnel_test.cpp)
-        if(TARGET fresnel_test)
-            target_link_libraries(fresnel_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-            target_include_directories(fresnel_test PRIVATE ${catkin_INCLUDE_DIRS})
-        endif()
-
-        catkin_add_gtest(timing_test test/timing_test.cpp)
-        if(TARGET timing_test)
-            target_link_libraries(timing_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-            target_include_directories(timing_test PRIVATE ${catkin_INCLUDE_DIRS})
-        endif()
-
-        catkin_add_gtest(jacobian_test test/jacobian_test.cpp)
-        if(TARGET jacobian_test)
-            target_link_libraries(jacobian_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-            target_include_directories(jacobian_test PRIVATE ${catkin_INCLUDE_DIRS})
-        endif()
-
-        catkin_add_gtest(hc_cc_circle_test test/hc_cc_circle_test.cpp)
-        if(TARGET hc_cc_circle_test)
-            target_link_libraries(hc_cc_circle_test ${catkin_LIBRARIES} ${PROJECT_NAME})
-            target_include_directories(hc_cc_circle_test PRIVATE ${catkin_INCLUDE_DIRS})
-        endif()
+        ament_package()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Eigen3 REQUIRED)
 message(STATUS "BUILD_WITH_ROS: ${BUILD_WITH_ROS}")
 
 if(BUILD_WITH_ROS)
+    find_package(ros_environment REQUIRED)
     set(ROS_VERSION $ENV{ROS_VERSION})
     message(STATUS "ROS_VERSION: '${ROS_VERSION}'")
     if(${ROS_VERSION} EQUAL 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ if(BUILD_WITH_ROS)
             ament_add_gtest(fresnel_test test/fresnel_test.cpp)
             target_link_libraries(fresnel_test ${PROJECT_NAME})
 
+            # TODO: also port this unit test
             # ament_add_gtest(timing_test test/timing_test.cpp)
             # target_link_libraries(timing_test ${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(steering_functions)
 
-set(PROJECT_VERSION 0.2.0)
+set(PROJECT_VERSION 0.2.1)
 
 option(BUILD_WITH_ROS "Build with ROS support" ON)
 
@@ -170,6 +170,6 @@ if(BUILD_WITH_ROS)
             target_link_libraries(hc_cc_circle_test ${PROJECT_NAME})
         endif()
 
-        # This package manages it's own package-config.cmake file, so its build_type is cmake and we don't call ament_package()
+        ## This package manages it's own package-config.cmake file, so its build_type is cmake and we don't call ament_package()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ if(BUILD_WITH_ROS)
     find_package(ros_environment REQUIRED)
     set(ROS_VERSION $ENV{ROS_VERSION})
     message(STATUS "ROS_VERSION: '${ROS_VERSION}'")
+    add_compile_definitions(ROS_VERSION=${ROS_VERSION})
     if(${ROS_VERSION} EQUAL 1)
         find_package(catkin REQUIRED COMPONENTS
             roscpp
@@ -151,15 +152,16 @@ if(BUILD_WITH_ROS)
     elseif(${ROS_VERSION} EQUAL 2)
         if(BUILD_TESTING)
             find_package(ament_cmake_gtest)
+            find_package(rclcpp REQUIRED)
+
             ament_add_gtest(steering_functions_test test/steering_functions_test.cpp TIMEOUT 240)
             target_link_libraries(steering_functions_test ${PROJECT_NAME})
 
             ament_add_gtest(fresnel_test test/fresnel_test.cpp)
             target_link_libraries(fresnel_test ${PROJECT_NAME})
 
-            # TODO: also port this unit test
-            # ament_add_gtest(timing_test test/timing_test.cpp)
-            # target_link_libraries(timing_test ${PROJECT_NAME})
+            ament_add_gtest(timing_test test/timing_test.cpp)
+            target_link_libraries(timing_test ${PROJECT_NAME} rclcpp::rclcpp)
 
             ament_add_gtest(jacobian_test test/jacobian_test.cpp)
             target_link_libraries(jacobian_test ${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -55,14 +55,65 @@ The source code in this package is released under the Apache-2.0 License. For fu
 The [3rdparty-licenses.txt](3rd-party-licenses.txt) contains a list of other open source components included in this package.
 
 
-## Installation & Usage as a ROS package
+## Installation & Usage as a [ROS2] package
 
 ### Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
 
     sudo apt-get install libeigen3-dev
 
-The [ROS] dependencies are listed in the package.xml and can be installed by
+The [ROS2] dependencies are listed in the package.xml and can be installed by
+
+    rosdep install steering_functions
+
+
+### Building
+
+To build this package from source, clone it into your workspace and compile it in *Release* mode according to
+
+    cd ros2_ws/src
+    git clone https://github.com/hbanzhaf/steering_functions.git
+    cd ..
+    colcon build --packages-up-to steering_functions --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+Note: the demo node is not yet ported to [ROS2], only the library functions are available.
+
+
+### Linking
+
+To link this library with another [ROS2] package, add these lines to your package's CMakeLists.txt
+
+    find_package(steering_functions REQUIRED)
+
+    target_link_libraries(your_target steering_functions::steering_functions)
+
+and the following lines to your package's package.xml
+
+    <depend>steering_functions</depend>
+
+Now the steering functions can be used in your package by including the appropriate header, e.g.
+
+    #include "steering_functions/hc_cc_state_space/hc00_reeds_shepp_state_space.hpp"
+
+
+### Testing
+
+    colcon test --packages-up-to steering_functions
+    colcon test-result --test-result-base build/steering_functions/
+
+To run a single test, e.g. the fresnel test, execute
+
+    ./build/steering_functions/fresnel_test
+
+
+## Installation & Usage as a ROS1 package
+
+### Dependencies
+This package depends on the linear algebra library [Eigen], which can be installed by
+
+    sudo apt-get install libeigen3-dev
+
+The [ROS1] dependencies are listed in the package.xml and can be installed by
 
     rosdep install steering_functions
 
@@ -83,7 +134,7 @@ To launch a demo of the package, execute
 
 ### Linking
 
-To link this library with another [ROS] package, add these lines to your package's CMakeLists.txt
+To link this library with another [ROS1] package, add these lines to your package's CMakeLists.txt
 
     find_package(catkin REQUIRED COMPONENTS
       steering_functions
@@ -206,6 +257,7 @@ In order to use the continuous and hybrid curvature state spaces along with [OMP
 Please use the [Issue Tracker](https://github.com/hbanzhaf/steering_functions/issues) to report bugs or request features.
 
 [ROS]: http://www.ros.org
+[ROS2]: https://docs.ros.org/en/rolling/
 [RViz]: http://wiki.ros.org/rviz
 [OMPL]: http://ompl.kavrakilab.org/
 [Eigen]: http://eigen.tuxfamily.org/

--- a/README.md
+++ b/README.md
@@ -55,33 +55,33 @@ The source code in this package is released under the Apache-2.0 License. For fu
 The [3rdparty-licenses.txt](3rd-party-licenses.txt) contains a list of other open source components included in this package.
 
 
-## Installation & Usage as a [ROS2] package
+## Installation & Usage as a [ROS 2] package
 
 ### Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
 
     sudo apt-get install libeigen3-dev
 
-The [ROS2] dependencies are listed in the package.xml and can be installed by
+The [ROS 2] dependencies are listed in the package.xml and can be installed by
 
     rosdep install steering_functions
 
 
 ### Building
 
-To build this package from source, clone it into your workspace and compile it in *Release* mode according to
+To build this package from source, clone it into your workspace and compile it in *Release* mode with the following commands. This will also build all tests.
 
     cd ros2_ws/src
     git clone https://github.com/hbanzhaf/steering_functions.git
     cd ..
     colcon build --packages-up-to steering_functions --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-Note: the demo node is not yet ported to [ROS2], only the library functions are available.
+Note that the demo node is not yet ported to [ROS 2], only the library functions are available.
 
 
 ### Linking
 
-To link this library with another [ROS2] package, add these lines to your package's CMakeLists.txt
+To link this library with another [ROS 2] package, add these lines to your package's CMakeLists.txt
 
     find_package(steering_functions REQUIRED)
 
@@ -98,6 +98,8 @@ Now the steering functions can be used in your package by including the appropri
 
 ### Testing
 
+To run the tests from this package, run the following commands:
+
     colcon test --packages-up-to steering_functions
     colcon test-result --test-result-base build/steering_functions/
 
@@ -106,14 +108,14 @@ To run a single test, e.g. the fresnel test, execute
     ./build/steering_functions/fresnel_test
 
 
-## Installation & Usage as a ROS1 package
+## Installation & Usage as a ROS 1 package
 
 ### Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
 
     sudo apt-get install libeigen3-dev
 
-The [ROS1] dependencies are listed in the package.xml and can be installed by
+The [ROS 1] dependencies are listed in the package.xml and can be installed by
 
     rosdep install steering_functions
 
@@ -134,7 +136,7 @@ To launch a demo of the package, execute
 
 ### Linking
 
-To link this library with another [ROS1] package, add these lines to your package's CMakeLists.txt
+To link this library with another [ROS 1] package, add these lines to your package's CMakeLists.txt
 
     find_package(catkin REQUIRED COMPONENTS
       steering_functions
@@ -257,7 +259,7 @@ In order to use the continuous and hybrid curvature state spaces along with [OMP
 Please use the [Issue Tracker](https://github.com/hbanzhaf/steering_functions/issues) to report bugs or request features.
 
 [ROS]: http://www.ros.org
-[ROS2]: https://docs.ros.org/en/rolling/
+[ROS 2]: https://docs.ros.org/en/rolling/
 [RViz]: http://wiki.ros.org/rviz
 [OMPL]: http://ompl.kavrakilab.org/
 [Eigen]: http://eigen.tuxfamily.org/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CC-Reeds-Shepp              | forwards **and** backwards | G<sup>2</sup> | path 
 
 [![Steering Functions for Car-Like Robots](https://img.youtube.com/vi/YCT8ycMk6f8/0.jpg)](http://www.youtube.com/watch?v=YCT8ycMk6f8)
 
-The package contains a [RViz] visualization, which has been tested with [ROS] Kinetic under Ubuntu 16.04.
+The package contains a [RViz] visualization, which has been tested with [ROS 1] Kinetic under Ubuntu 16.04.
 
 A video of the steering functions integrated into the general motion planner Bidirectional RRT* can be found [here](https://youtu.be/RlZZ4jnEhTM).
 
@@ -55,17 +55,17 @@ The source code in this package is released under the Apache-2.0 License. For fu
 The [3rdparty-licenses.txt](3rd-party-licenses.txt) contains a list of other open source components included in this package.
 
 
-## Installation & Usage as a [ROS 2] package
-
-### Dependencies
+## Dependencies
 This package depends on the linear algebra library [Eigen], which can be installed by
 
     sudo apt-get install libeigen3-dev
 
-The [ROS 2] dependencies are listed in the package.xml and can be installed by
+If you are using ROS, you can automatically install all dependencies that are listed in the `package.xml` with
 
     rosdep install steering_functions
 
+
+## Installation & Usage as a [ROS 2] package
 
 ### Building
 
@@ -108,17 +108,7 @@ To run a single test, e.g. the fresnel test, execute
     ./build/steering_functions/fresnel_test
 
 
-## Installation & Usage as a ROS 1 package
-
-### Dependencies
-This package depends on the linear algebra library [Eigen], which can be installed by
-
-    sudo apt-get install libeigen3-dev
-
-The [ROS 1] dependencies are listed in the package.xml and can be installed by
-
-    rosdep install steering_functions
-
+## Installation & Usage as a [ROS 1] package
 
 ### Building
 
@@ -171,11 +161,6 @@ To run a single test, e.g. the timing test, execute
 
 
 ## Installation & Usage as a standalone library
-
-### Dependencies
-This package depends on the linear algebra library [Eigen], which can be installed by
-
-    sudo apt-get install libeigen3-dev
 
 ### Building
 
@@ -258,7 +243,7 @@ In order to use the continuous and hybrid curvature state spaces along with [OMP
 ## Bugs & Feature Requests
 Please use the [Issue Tracker](https://github.com/hbanzhaf/steering_functions/issues) to report bugs or request features.
 
-[ROS]: http://www.ros.org
+[ROS 1]: http://www.ros.org
 [ROS 2]: https://docs.ros.org/en/rolling/
 [RViz]: http://wiki.ros.org/rviz
 [OMPL]: http://ompl.kavrakilab.org/

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
   <depend condition="$ROS_VERSION == 1">visualization_msgs</depend>
   <depend>eigen</depend>
 
+  <test_depend condition="$ROS_VERSION == 2">rclcpp</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_ros</buildtool_depend>
 
   <build_depend condition="$ROS_VERSION == 1">cmake_modules</build_depend>
+  <build_depend>ros_environment</build_depend>
   <depend condition="$ROS_VERSION == 1">costmap_2d</depend>
   <depend condition="$ROS_VERSION == 1">geometry_msgs</depend>
   <depend condition="$ROS_VERSION == 1">nav_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>steering_functions</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The steering_functions package</description>
 
   <maintainer email="holger.banzhaf@de.bosch.com">Holger Banzhaf</maintainer>
@@ -13,8 +13,9 @@
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_ros</buildtool_depend>
 
-  <build_depend condition="$ROS_VERSION == 1">cmake_modules</build_depend>
   <build_depend>ros_environment</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">cmake_modules</build_depend>
+
   <depend condition="$ROS_VERSION == 1">costmap_2d</depend>
   <depend condition="$ROS_VERSION == 1">geometry_msgs</depend>
   <depend condition="$ROS_VERSION == 1">nav_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,6 @@
   <depend>eigen</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>steering_functions</name>
   <version>0.2.0</version>
   <description>The steering_functions package</description>
@@ -9,28 +10,20 @@
 
   <license>Apache-2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_ros</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>roslib</build_depend>
-  <build_depend>costmap_2d</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>eigen</build_depend>
-
-  <run_depend>roscpp</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>costmap_2d</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>eigen</run_depend>
+  <build_depend condition="$ROS_VERSION == 1">cmake_modules</build_depend>
+  <depend condition="$ROS_VERSION == 1">costmap_2d</depend>
+  <depend condition="$ROS_VERSION == 1">geometry_msgs</depend>
+  <depend condition="$ROS_VERSION == 1">nav_msgs</depend>
+  <depend condition="$ROS_VERSION == 1">roscpp</depend>
+  <depend condition="$ROS_VERSION == 1">roslib</depend>
+  <depend condition="$ROS_VERSION == 1">tf</depend>
+  <depend condition="$ROS_VERSION == 1">visualization_msgs</depend>
+  <depend>eigen</depend>
 
   <export>
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Hello,

I've ported this package partially to ROS2 so the library can be used by other packages. Most of the tests still work :)

I did not yet port the node, but that could be done in a different PR.

@vebjornjr I changed the install location of the `-config.cmake` files so that they can be found by other packages. Does this still work in your setup?